### PR TITLE
whiteList() fix

### DIFF
--- a/safemysql.class.php
+++ b/safemysql.class.php
@@ -176,12 +176,12 @@ class SafeMySQL
 
 	public function whiteList($input,$allowed,$strict=FALSE)
 	{
-		$found = array_search($input);
+		$found = array_search($input,$allowed);
 		if ($strict && ($found === FALSE))
 		{
 			return FALSE;
 		} else {
-			return $allowed[$found];
+			return $allowed[(int)$found];
 		}
 	}
 


### PR DESCRIPTION
В array_search забыт второй аргумент, а в не-$strict ветке не очень понятно, что должно вернуться, если $found === FALSE
