### PR TITLE
Update safemysql.class.php

### DIFF
--- a/safemysql.class.php
+++ b/safemysql.class.php
@@ -104,6 +104,20 @@ class SafeMySQL
 		mysqli_set_charset($this->conn, $opt['charset']) or $this->error(mysqli_error($this->conn));
 		unset($opt); // I am paranoid
 	}
+	/**
+	 * Static function to call the class without creating a new instance
+	 * @param array $opt
+	 *
+	 * @return SafeMySQL
+	 */
+	static public function getInstanse($opt = array())
+	{
+		static $db;
+		if (!is_object($db)) {
+			$db = new SafeMySQL($opt);
+		}
+		return $db;
+	}
 
 	/**
 	 * Conventional function to run a query with placeholders. A mysqli_query wrapper with placeholders support


### PR DESCRIPTION
Вчера на одном из проектов обнаружил, что немного модифицировал класс, добавив возможность вызова без создания нового экземпляра.
Уже не помню по какой причине это было сделано, но вдруг окажется полезным, поэтому решил оформить pull request.

В проекте у меня используется так:
```php
class ClassName
{
    public function __construct()
    {
        $this->db = $this->getDb();
    }
    public function getDb()
    {
        return SafeMySQL::getInstanse(array(
            'host'    => DBHOST,
            'user'    => DBUSER,
            'pass'    => DBPASS,
            'db'      => DBNAME,
            'charset' => COLLATE,
        ));
    }
}
```